### PR TITLE
Stop using services in html for speechbar component

### DIFF
--- a/src/app/speechbar.service.ts
+++ b/src/app/speechbar.service.ts
@@ -10,20 +10,23 @@ export class SpeechbarService {
   private buttons: Button[] = [];
   private speechSynthesizer: SpeechSynthesis = (<any>window).speechSynthesis;
   private listener: Observer<boolean>;
+  private buttonObserver: Observer<Button[]>;
 
   constructor() { }
 
   addButton(button: Button) {
     this.buttons.push(button);
-    console.log(button.label);  // TODO : remove
+    this.notifyButtonObserver();
   }
 
   clear() {
     this.buttons = [];
+    this.notifyButtonObserver();
   }
 
   backspace() {
     this.buttons.pop();
+    this.notifyButtonObserver();
   }
 
   speak() {
@@ -35,16 +38,24 @@ export class SpeechbarService {
       msg.onstart = () => this.listener.next(true);
       msg.onend = () => this.listener.next(false);
       this.speechSynthesizer.speak(msg);
-
     }
   }
 
-  getButtons() {
-    return this.buttons;
+  private notifyButtonObserver() {
+    this.buttonObserver.next(this.buttons);
+  }
+
+  getButtons(): Observable<Button[]> {
+    return new Observable<Button[]>(this.addButtonObserver);
   }
 
   getSpeaking(): Observable<boolean> {
     return new Observable<boolean>(this.addListener);
+  }
+
+  addButtonObserver = (observer: Observer<Button[]>) => {
+    this.buttonObserver = observer;
+    this.buttonObserver.next(this.buttons);
   }
 
   addListener = (listener: Observer<boolean>) => {

--- a/src/app/speechbar/speechbar.component.html
+++ b/src/app/speechbar/speechbar.component.html
@@ -1,20 +1,20 @@
 <div class="speechbarContainer">
   <div class="stackedButtonContainer">
-    <button class="stackedButton" mat-raised-button (click)="speechbarService.speak()"
+    <button class="stackedButton" mat-raised-button (click)="speak()"
             [disabled]="speaking"
             *ngIf="displayedButtons.showSpeakButton">Speak</button>
-    <button class="stackedButton" mat-raised-button (click)="boardService.home()"
+    <button class="stackedButton" mat-raised-button (click)="home()"
             *ngIf="displayedButtons.showHomeButton">Home</button>
   </div>
 
   <mat-card class="speechbar" *ngIf="showIconsInSpeechbar; else vocalization" (click)="speechbarClick()">
-    <div class="speechbarButtonItem" *ngFor="let butt of speechbarService.getButtons()">
+    <div class="speechbarButtonItem" *ngFor="let butt of buttons">
       <app-obf-button [butt]="butt"></app-obf-button>
     </div>
   </mat-card>
   <ng-template #vocalization>
     <mat-card class="speechbar">
-      <div class="speechbarTextItem" *ngFor="let butt of speechbarService.getButtons()">
+      <div class="speechbarTextItem" *ngFor="let butt of buttons">
         <mat-card class="speechbarText">
           {{butt.getVocalization()}}
         </mat-card>
@@ -23,9 +23,9 @@
   </ng-template>
 
   <div class="stackedButtonContainer">
-    <button class="stackedButton" mat-raised-button (click)="speechbarService.backspace()"
+    <button class="stackedButton" mat-raised-button (click)="backspace()"
             *ngIf="displayedButtons.showBackspaceButton">Backspace</button>
-    <button class="stackedButton" mat-raised-button (click)="speechbarService.clear()"
+    <button class="stackedButton" mat-raised-button (click)="clear()"
             *ngIf="displayedButtons.showClearButton">Clear</button>
   </div>
 </div>

--- a/src/app/speechbar/speechbar.component.spec.ts
+++ b/src/app/speechbar/speechbar.component.spec.ts
@@ -29,7 +29,7 @@ describe('SpeechbarComponent', () => {
     };
     boardServiceStub = {};
     speechbarServiceStub = {
-      getButtons: () => [],
+      getButtons: () => new Observable(() => {}),
       getSpeaking: () => new Observable(() => {})
     };
 

--- a/src/app/speechbar/speechbar.component.ts
+++ b/src/app/speechbar/speechbar.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { ConfigService, ButtonDisplayConfig } from '../config.service';
 import { SpeechbarService } from '../speechbar.service';
 import { Subscription } from 'rxjs';
+import { BoardService } from '../board.service';
+import { Button } from '../obfboard';
 
 @Component({
   selector: 'app-speechbar',
@@ -13,8 +15,10 @@ export class SpeechbarComponent implements OnInit, OnDestroy {
   private _showIconsInSpeechbar: boolean;
   private speakingSubscription: Subscription;
   speaking: boolean;
+  buttons: Button[];
 
   constructor(
+    private boardService: BoardService,
     private speechbarService: SpeechbarService,
     private config: ConfigService,
     private cdRef: ChangeDetectorRef
@@ -26,6 +30,9 @@ export class SpeechbarComponent implements OnInit, OnDestroy {
     this.speakingSubscription = this.speechbarService.getSpeaking().subscribe(speaking => {
       this.speaking = speaking;
       this.cdRef.detectChanges();
+    });
+    this.speechbarService.getButtons().subscribe(buttons => {
+      this.buttons = buttons;
     });
   }
 
@@ -45,5 +52,21 @@ export class SpeechbarComponent implements OnInit, OnDestroy {
     if (this.config.speakOnSpeechbarClick) {
       this.speechbarService.speak();
     }
+  }
+
+  speak() {
+    this.speechbarService.speak();
+  }
+
+  home() {
+    this.boardService.home();
+  }
+
+  backspace() {
+    this.speechbarService.backspace();
+  }
+
+  clear() {
+    this.speechbarService.clear();
   }
 }


### PR DESCRIPTION
I've set up the buttons as an observable so we can stop using the services directly in the html.

The reason this bug occurred was because it wasn't obvious that the boardService was in use as none of the code in the ts file used it.  So I removed it.  Obviously if we had more thorough component tests this would probably have picked this up.
But anyway.  It's probably bad practise to use 'foreign' services and things in the html, we should endeavour to only use local properties and methods.