### PR TITLE
Allow dependabot PRs to run checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@
 name: Build and Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - 'develop'
   workflow_call:
@@ -15,6 +15,10 @@ on:
       coverage:
         description: "Whether the minimum code coverage was met"
         value: ${{ jobs.build.outputs.coverage }}
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
 
 
 jobs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@
 name: Build and Test
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - 'develop'
   workflow_call:


### PR DESCRIPTION
The github action flow was changed to not allow dependabot PRs any workflow permissions, which means they can't publish the code coverage or test results checks (and therefore they can't be merged, as even rerunning them manually does not get around this).
This was a security feature to prevent secrets being scraped by malicious thrid party libraries that pushed a new version. Details here: https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544

The workarounds are to either change the build trigger to "pull_request_target" (from "pull_request"), to have two extra workflows for dependabot builds (one that checks it's a dependabot PR and triggers the other), or to set the permissions explicitly in the workflow (https://docs.github.com/en/code-security/dependabot/troubleshooting-dependabot/troubleshooting-dependabot-on-github-actions#changing-github_token-permissions).
All of these workarounds (and any workaround that actually allows dependabot PRs to build automatically) reintroduces the same potential security risk.

However, the only build we have that actually uses secrets is the staging deployment, which can't run from dependabot anyway as it's only run on push to develop. (Leaving this intact means we need to always merge dependabot PRs manually, rather than using "@dependabot merge", but that shouldn't be a problem.)
We possibly should have a separate repo for the production deployment, which therefore has a separate secret and is more protected than it just being the github pages branch of this repo, but that's a problem we already have (#220).