### PR TITLE
Switch back to browser builder

### DIFF
--- a/.github/actions/deploy-to-gh-pages-action/action.yaml
+++ b/.github/actions/deploy-to-gh-pages-action/action.yaml
@@ -43,7 +43,7 @@ runs:
     - name: Npm install extras
       shell: bash
       run: |
-        npm install -g @angular/cli@11.2.12
+        npm install -g @angular/cli@19.2.13
         npm install -g workbox-cli@3.6.3
         npm install
 

--- a/angular.json
+++ b/angular.json
@@ -11,12 +11,11 @@
       "schematics": {},
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": {
-              "base": "dist/open-voice-factory"
-            },
+            "outputPath": "dist/open-voice-factory",
             "index": "src/index.html",
+            "main": "src/main.ts",
             "polyfills": ["zone.js"],
             "tsConfig": "src/tsconfig.app.json",
             "assets": [
@@ -50,8 +49,7 @@
             "extractLicenses": false,
             "sourceMap": true,
             "optimization": false,
-            "namedChunks": true,
-            "browser": "src/main.ts"
+            "namedChunks": true
           },
           "configurations": {
             "production": {
@@ -74,12 +72,6 @@
               "extractLicenses": true
             },
             "staging": {
-              "budgets": [
-                {
-                  "type": "any",
-                  "maximumWarning": "6kb"
-                }
-              ],
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",


### PR DESCRIPTION
The staging deployment is broken because the angular upgrade to the 'application' builder means the deployment builds are all nested inside a /browser folder, to allow deployments to use server side rendering. However, we don't have a server, so we should be explicitly still using the 'browser' builder so that the github pages hosting works.