### PR TITLE
Issue #232 - Fix board caching

### DIFF
--- a/src/app/obfboard.ts
+++ b/src/app/obfboard.ts
@@ -85,91 +85,31 @@ export class Button {
 
   @IsNotEmpty({ message: 'Button id must be specified' })
   @IsString({ message: 'Button id must be a string' })
-  private _id: string;
-  public get id(): string {
-    return this._id;
-  }
-  public set id(value: string) {
-    this._id = value;
-  }
+  id: string;
 
   @IsNotEmpty()
   @IsString()
-  private _label: string;
-  public get label(): string {
-    return this._label;
-  }
-  public set label(value: string) {
-    this._label = value;
-  }
+  label: string;
 
   @IsOptional()
   @IsString()
-  private _vocalization: string;
-  public get vocalization(): string {
-    return this._vocalization;
-  }
-  public set vocalization(value: string) {
-    this._vocalization = value;
-  }
+  vocalization: string;
 
   @IsOptional()
   @IsString()
-  private _imageId: string;
-  public get imageId(): string {
-    return this._imageId;
-  }
-  public set imageId(value: string) {
-    this._imageId = value;
-  }
+  imageId: string;
 
   @IsOptional()
   @IsString()
-  private _soundId: string;
-  public get soundId(): string {
-    return this._soundId;
-  }
-  public set soundId(value: string) {
-    this._soundId = value;
-  }
+  soundId: string;
 
-  private _backgroundColor: string;
-  public get backgroundColor(): string {
-    return this._backgroundColor;
-  }
-  public set backgroundColor(value: string) {
-    this._backgroundColor = value;
-  }
-  private _borderColor: string;
-  public get borderColor(): string {
-    return this._borderColor;
-  }
-  public set borderColor(value: string) {
-    this._borderColor = value;
-  }
-  private _actions: string[];
-  public get actions(): string[] {
-    return this._actions;
-  }
-  public set actions(value: string[]) {
-    this._actions = value;
-  }
-  private _loadBoardAction: LoadBoardAction;
-  public get loadBoardAction(): LoadBoardAction {
-    return this._loadBoardAction;
-  }
-  public set loadBoardAction(value: LoadBoardAction) {
-    this._loadBoardAction = value;
-  }
+  backgroundColor: string;
+  borderColor: string;
+  actions: string[];
+  loadBoardAction: LoadBoardAction;
 
   @IsDefined()
-  private _parent: OBFBoard;
-  public get parent(): OBFBoard {
-    return this._parent;
-  }
-  public set parent(value: OBFBoard) {
-    this._parent = value;
-  }
+  parent: OBFBoard;
 
   deserialize(input: any, parent: OBFBoard): Button {
     this.id = stringify(input.id);

--- a/src/app/services/board/board-cache.service.spec.ts
+++ b/src/app/services/board/board-cache.service.spec.ts
@@ -22,7 +22,7 @@ import { OBFBoard } from 'src/app/obfboard';
 describe('BoardCacheService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [ BoardCacheService ]
+      providers: [BoardCacheService]
     });
   });
 
@@ -72,7 +72,7 @@ describe('BoardCacheService', () => {
     inject([BoardCacheService, StorageMap], (service: BoardCacheService, localStorage: StorageMap) => {
       spyOn(localStorage, 'get').and.returnValue(of(null));
       service.retrieve().subscribe({
-        next: () => {},
+        next: () => { },
         error: (err) => {
           expect(err).toBeTruthy();
           done();
@@ -83,7 +83,7 @@ describe('BoardCacheService', () => {
   });
 
   it('should be able to put a board into the cache and get it back out again', (done) => {
-    
+
     inject([BoardCacheService], (service: BoardCacheService) => {
       spyOn(service, 'getCacheKey').and.returnValue('cache_test_only');
 
@@ -126,25 +126,33 @@ describe('BoardCacheService', () => {
       };
       const testBoard = new OBFBoard().deserialize(testBoardJSON);
       boardSet.setBoard('test', testBoard);
-      
+
       // does this want to fail? or just warn?
       // Failure means the test can never get cleaned up because we don't then run the delete
       // Warning means the test can never end up deleting real data that has a key clash (may be irrelevant due to domain scoping?)
-      service.retrieve().subscribe({next: () => { done.fail('Cache contains "test" item before test') }, error: () => {
-        const cleanup = (callback: () => void) => {
-          service.clear().subscribe({next: () => {
-            service.retrieve().subscribe({next: () => { done.fail('Cache contains "test" item after test') }, error: () => { callback(); }});
-          }, error: done.fail});
-        };
+      service.retrieve().subscribe({
+        next: () => { done.fail('Cache contains "test" item before test') }, error: () => {
+          const cleanup = (callback: () => void) => {
+            service.clear().subscribe({
+              next: () => {
+                service.retrieve().subscribe({ next: () => { done.fail('Cache contains "test" item after test') }, error: () => { callback(); } });
+              }, error: done.fail
+            });
+          };
 
-        service.save(boardSet).subscribe({next: (ret) => {
-          expect(ret).toBe(boardSet);
-          service.retrieve().subscribe({next: (ret) => {
-            expect(ret).toEqual(boardSet);
-            cleanup(done);
-          }, error: (err) => { cleanup(() => { done.fail(err); }); }});
-        }, error: (err) => { cleanup(() => { done.fail(err); }); } });
-        }});
+          service.save(boardSet).subscribe({
+            next: (ret) => {
+              expect(ret).toBe(boardSet);
+              service.retrieve().subscribe({
+                next: (ret) => {
+                  expect(ret).toEqual(boardSet);
+                  cleanup(done);
+                }, error: (err) => { cleanup(() => { done.fail(err); }); }
+              });
+            }, error: (err) => { cleanup(() => { done.fail(err); }); }
+          });
+        }
+      });
     })();
   });
 });

--- a/src/app/services/board/board-cache.service.spec.ts
+++ b/src/app/services/board/board-cache.service.spec.ts
@@ -85,6 +85,8 @@ describe('BoardCacheService', () => {
   it('should be able to put a board into the cache and get it back out again', (done) => {
     
     inject([BoardCacheService], (service: BoardCacheService) => {
+      spyOn(service, 'getCacheKey').and.returnValue('cache_test_only');
+
       const boardSet = new OBZBoardSet();
       boardSet.rootBoardKey = undefined;
       const testBoardJSON = {
@@ -124,14 +126,25 @@ describe('BoardCacheService', () => {
       };
       const testBoard = new OBFBoard().deserialize(testBoardJSON);
       boardSet.setBoard('test', testBoard);
+      
+      // does this want to fail? or just warn?
+      // Failure means the test can never get cleaned up because we don't then run the delete
+      // Warning means the test can never end up deleting real data that has a key clash (may be irrelevant due to domain scoping?)
+      service.retrieve().subscribe({next: () => { done.fail('Cache contains "test" item before test') }, error: () => {
+        const cleanup = (callback: () => void) => {
+          service.clear().subscribe({next: () => {
+            service.retrieve().subscribe({next: () => { done.fail('Cache contains "test" item after test') }, error: () => { callback(); }});
+          }, error: done.fail});
+        };
 
-      service.save(boardSet).subscribe({next: (ret) => {
-        expect(ret).toBe(boardSet);
-        service.retrieve().subscribe({next: (ret) => {
-          expect(ret).toEqual(boardSet);
-          done();
-        }, error: done.fail });
-      }, error: done.fail });
+        service.save(boardSet).subscribe({next: (ret) => {
+          expect(ret).toBe(boardSet);
+          service.retrieve().subscribe({next: (ret) => {
+            expect(ret).toEqual(boardSet);
+            cleanup(done);
+          }, error: (err) => { cleanup(() => { done.fail(err); }); }});
+        }, error: (err) => { cleanup(() => { done.fail(err); }); } });
+        }});
     })();
   });
 });

--- a/src/app/services/board/board-cache.service.spec.ts
+++ b/src/app/services/board/board-cache.service.spec.ts
@@ -17,6 +17,7 @@ import { BoardCacheService } from './board-cache.service';
 import { StorageMap } from '@ngx-pwa/local-storage';
 import { of } from 'rxjs';
 import { OBZBoardSet } from '../../obzboard-set';
+import { OBFBoard } from 'src/app/obfboard';
 
 describe('BoardCacheService', () => {
   beforeEach(() => {
@@ -78,6 +79,59 @@ describe('BoardCacheService', () => {
         }
       });
       expect(localStorage.get).toHaveBeenCalled();
+    })();
+  });
+
+  it('should be able to put a board into the cache and get it back out again', (done) => {
+    
+    inject([BoardCacheService], (service: BoardCacheService) => {
+      const boardSet = new OBZBoardSet();
+      boardSet.rootBoardKey = undefined;
+      const testBoardJSON = {
+        format: 'board_format',
+        id: 5,
+        locale: 'en_GB',
+        name: 'board_name',
+        description_html: '<b>desc</b>',
+        grid: {
+          rows: 2,
+          columns: 2,
+          order: [[1, null],
+          [null, 2]]
+        },
+        buttons: [
+          {
+            id: 1,
+            label: 'button1'
+          },
+          {
+            id: 2,
+            label: 'button2'
+          }
+        ],
+        images: [
+          {
+            id: 1,
+            url: 'http://example.com'
+          }
+        ],
+        sounds: [
+          {
+            id: 1,
+            url: 'http://another.com'
+          }
+        ]
+      };
+      const testBoard = new OBFBoard().deserialize(testBoardJSON);
+      boardSet.setBoard('test', testBoard);
+
+      service.save(boardSet).subscribe({next: (ret) => {
+        expect(ret).toBe(boardSet);
+        service.retrieve().subscribe({next: (ret) => {
+          expect(ret).toEqual(boardSet);
+          done();
+        }, error: done.fail });
+      }, error: done.fail });
     })();
   });
 });

--- a/src/app/services/board/board-cache.service.spec.ts
+++ b/src/app/services/board/board-cache.service.spec.ts
@@ -127,9 +127,6 @@ describe('BoardCacheService', () => {
       const testBoard = new OBFBoard().deserialize(testBoardJSON);
       boardSet.setBoard('test', testBoard);
 
-      // does this want to fail? or just warn?
-      // Failure means the test can never get cleaned up because we don't then run the delete
-      // Warning means the test can never end up deleting real data that has a key clash (may be irrelevant due to domain scoping?)
       service.retrieve().subscribe({
         next: () => { done.fail('Cache contains "test" item before test') }, error: () => {
           const cleanup = (callback: () => void) => {

--- a/src/app/services/board/board-cache.service.ts
+++ b/src/app/services/board/board-cache.service.ts
@@ -18,6 +18,7 @@ import { OBZBoardSet, SavedOBZBoardSet } from '../../obzboard-set';
 import { Observable } from 'rxjs';
 import { map, first } from 'rxjs/operators';
 import { OBFBoard } from '../../obfboard';
+import { VERSION } from '../../../environments/version';
 
 @Injectable({
   providedIn: 'root'
@@ -28,13 +29,17 @@ export class BoardCacheService {
 
   constructor(private localStorage: StorageMap) { }
 
-  public clear(): Observable<boolean> {
+  private getCacheKey(): string {
+    return BoardCacheService.BOARD_CACHE_KEY + (VERSION.tag.startsWith('DEV') ? 'DEV' : '');
+  }
+
+  public clear(): Observable<undefined> {
     this.log('Clearing local board cache');
-    return this.localStorage.delete(BoardCacheService.BOARD_CACHE_KEY).pipe(first());
+    return this.localStorage.delete(this.getCacheKey());
   }
 
   public retrieve(): Observable<OBZBoardSet> {
-    return this.localStorage.get(BoardCacheService.BOARD_CACHE_KEY).pipe(map((data: SavedOBZBoardSet) => {
+    return this.localStorage.get(this.getCacheKey()).pipe(map((data: SavedOBZBoardSet) => {
       if (data) {
         this.log('Successfully loaded board from cache');
 
@@ -62,7 +67,7 @@ export class BoardCacheService {
   }
 
   public save(boardSet: OBZBoardSet): Observable<OBZBoardSet> {
-    return this.localStorage.set(BoardCacheService.BOARD_CACHE_KEY, boardSet).pipe(
+    return this.localStorage.set(this.getCacheKey(), boardSet).pipe(
       map(success => boardSet),
       first()
     );

--- a/src/app/services/board/board-cache.service.ts
+++ b/src/app/services/board/board-cache.service.ts
@@ -29,7 +29,7 @@ export class BoardCacheService {
 
   constructor(private localStorage: StorageMap) { }
 
-  private getCacheKey(): string {
+  public getCacheKey(): string {
     return BoardCacheService.BOARD_CACHE_KEY + (VERSION.tag.startsWith('DEV') ? 'DEV' : '');
   }
 

--- a/src/app/services/speechbar/speechbar.service.ts
+++ b/src/app/services/speechbar/speechbar.service.ts
@@ -13,19 +13,17 @@ You should have received a copy of the GNU General Public License
 along with OVFPlayer.  If not, see <https://www.gnu.org/licenses/>.
 ::END::LICENCE:: */
 import { Injectable } from '@angular/core';
-import { Button, Image, OBFBoard, LoadBoardAction } from '../../obfboard';
+import { Button } from '../../obfboard';
 import { Observable, Observer } from 'rxjs';
 import { ConfigService } from '../config/config.service';
 
 export class ButtonFacade extends Button {
 
-  private button: Button;
   private appendages: string[] = [];
 
   constructor(button: Button) {
     super();
-    this.button = button;
-    // copies all the button properties into this facade because we can't override properties with accessors
+    // copies all the button properties into this "facade" because we can't override properties with accessors
     this.deserialize(JSON.parse(JSON.stringify(button)), button.parent);
   }
 

--- a/src/app/services/speechbar/speechbar.service.ts
+++ b/src/app/services/speechbar/speechbar.service.ts
@@ -25,62 +25,22 @@ export class ButtonFacade extends Button {
   constructor(button: Button) {
     super();
     this.button = button;
+    // copies all the button properties into this facade because we can't override properties with accessors
+    this.deserialize(JSON.parse(JSON.stringify(button)), button.parent);
   }
 
   append(appendage: string) {
     this.appendages.push(appendage);
-  }
-
-  getVocalization(): string {
-    return this.vocalization || this.label;
-  }
-
-  getImage(): Image {
-    return this.button.getImage();
+    this.update();
   }
 
   private augment(initial: string): string {
     return [initial].concat(this.appendages).join('');
   }
 
-  get id(): string {
-    return this.button.id;
-  }
-
-  get label(): string {
-    return this.augment(this.button.label);
-  }
-
-  get vocalization(): string {
-    return this.button.vocalization ? this.augment(this.button.vocalization) : this.button.vocalization;
-  }
-
-  get imageId(): string {
-    return this.button.imageId;
-  }
-
-  get soundId(): string {
-    return this.button.soundId;
-  }
-
-  get backgroundColor(): string {
-    return this.button.backgroundColor;
-  }
-
-  get borderColor(): string {
-    return this.button.borderColor;
-  }
-
-  get actions(): string[] {
-    return this.button.actions;
-  }
-
-  get loadBoardAction(): LoadBoardAction {
-    return this.button.loadBoardAction;
-  }
-
-  get parent(): OBFBoard {
-    return this.button.parent;
+  private update() {
+    this.label = this.augment(this.label);
+    this.vocalization = this.vocalization ? this.augment(this.vocalization) : this.vocalization;
   }
 }
 


### PR DESCRIPTION
The ButtonFacade is now no longer a facade... 
Other options include: 
1. Not extending Button and changing the speechbar component to explicitly use ButtonFacade (still not really a facade, but no copying)
2. Putting it back to pre typescript 4 state and ignoring the typescipt warning for the declaration of ButtonFacade
3. Making the deserialisation work with both underscored and non-underscored properties (prefering non-underscored where present)
4. A magic, much better, different approach that someone suggests