### PR TITLE
Issue #91: Only clear cache when board url is changed or user requests a reload.

### DIFF
--- a/src/app/config-page/config-page.component.html
+++ b/src/app/config-page/config-page.component.html
@@ -21,6 +21,7 @@ along with OVFPlayer.  If not, see <https://www.gnu.org/licenses/>.
 
       <div class="formButtons">
         <button type="submit" mat-raised-button color="primary" [disabled]="!configForm.form.valid">Save</button>
+        <button type="button" mat-raised-button color="primary" (click)="exitConfig()">Cancel</button>
       </div>
       <mat-tab-group>
         <mat-tab ngModelGroup="boardURL" #boardURLCtrl="ngModelGroup">
@@ -36,10 +37,15 @@ along with OVFPlayer.  If not, see <https://www.gnu.org/licenses/>.
                 <input [(ngModel)]="boardURL" required matInput name="boardURL" placeholder="URL for obf/obz file"
                   class="formInputUrl">
               </mat-form-field>
-              <div class="clickable" (click)="copyToClipboard()"><i class="material-icons">link</i>&nbsp;Create link</div>
+              <div class="clickable" (click)="copyToClipboard()"><i class="material-icons">link</i>&nbsp;Create link
+              </div>
+              <div class="clickable" (click)="refreshBoard()"><i class="material-icons">refresh</i>&nbsp;Reload board
+                without changes</div>
               <div>
-                <button id="useCK20" mat-raised-button type="button" (click)="resetToCK20()">Use default CK20 board</button>
-                <button id="useCK12" mat-raised-button type="button" (click)="resetToCK12()">Use default CK12 board</button>
+                <button id="useCK20" mat-raised-button type="button" (click)="resetToCK20()">Use default CK20
+                  board</button>
+                <button id="useCK12" mat-raised-button type="button" (click)="resetToCK12()">Use default CK12
+                  board</button>
               </div>
             </mat-card>
           </div>

--- a/src/app/config-page/config-page.component.ts
+++ b/src/app/config-page/config-page.component.ts
@@ -14,8 +14,10 @@ along with OVFPlayer.  If not, see <https://www.gnu.org/licenses/>.
 ::END::LICENCE:: */
 import { Component, OnInit } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
-import { ConfigService, ButtonDisplayConfig, ScanningConfig, AppearanceConfig, ButtonBehaviourConfig,
-  InteractionEventType, VoiceConfig} from '../services/config/config.service';
+import {
+  ConfigService, ButtonDisplayConfig, ScanningConfig, AppearanceConfig, ButtonBehaviourConfig,
+  InteractionEventType, VoiceConfig
+} from '../services/config/config.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { VERSION } from '../../environments/version';
 import { BoardCacheService } from '../services/board/board-cache.service';
@@ -34,10 +36,10 @@ import { MatSelect, MatOption } from '@angular/material/select';
 import { MatSlider, MatSliderThumb } from '@angular/material/slider';
 
 @Component({
-    selector: 'app-config-page',
-    templateUrl: './config-page.component.html',
-    styleUrls: ['./config-page.component.css'],
-    imports: [OBFPageComponent, MatCard, FormsModule, MatButton, MatTabGroup, MatTab, MatTabLabel, MatIcon, MatFormField, MatInput, MatCheckbox, MatRadioGroup, MatRadioButton, MatSelect, MatOption, MatSlider, MatSliderThumb]
+  selector: 'app-config-page',
+  templateUrl: './config-page.component.html',
+  styleUrls: ['./config-page.component.css'],
+  imports: [OBFPageComponent, MatCard, FormsModule, MatButton, MatTabGroup, MatTab, MatTabLabel, MatIcon, MatFormField, MatInput, MatCheckbox, MatRadioGroup, MatRadioButton, MatSelect, MatOption, MatSlider, MatSliderThumb]
 })
 export class ConfigPageComponent implements OnInit {
 
@@ -81,7 +83,26 @@ export class ConfigPageComponent implements OnInit {
     return JSON.parse(JSON.stringify(config));
   }
 
+  refreshBoard() {
+    this.boardCache.clear().subscribe({
+      next: () => {
+        this.exitConfig();
+      },
+      error: (error) => {
+        // not much we can do really
+        console.error('Error clearing cache', error);
+        this.exitConfig();
+      }
+    });
+  }
+
+  exitConfig() {
+    this.router.navigate(['/main']);
+  }
+
   save() {
+    const clearCache = this.configService.boardURL != this.boardURL;
+
     this.configService.boardURL = this.boardURL;
     this.configService.displayedButtons = this.displayedButtons;
     this.configService.showIconsInSpeechbar = this.showIconsInSpeechbar;
@@ -92,17 +113,13 @@ export class ConfigPageComponent implements OnInit {
     this.configService.voiceConfig = this.voiceConfig;
     // TODO: some kind of validation
 
-    // clear local cache of page to force a refresh
-    this.boardCache.clear().subscribe({
-      next: () => {
-        this.router.navigate(['/main']);
-      },
-      error: (error) => {
-        // not much we can do really
-        console.error('Error clearing cache', error);
-        this.router.navigate(['/main']);
-      }
-    });
+    // clear local cache of page to force a refresh if board url has changed
+    if (clearCache) {
+      this.refreshBoard();
+    }
+    else {
+      this.exitConfig();  // otherwise just go back to main page
+    }
   }
 
   copyToClipboard() {


### PR DESCRIPTION
Closes #91 
Is it this simple?

Obviously for #181 we'd want to do something cleverer with keeping the previous board under a different key in the cache or something...

And obviously if we wanted to support a school situation with a "daily refresh" setting type thing that would also want something cleverer, maybe with a "time to refresh" in the local storage or something...

But... for this specific issue, is this all it needs?